### PR TITLE
fix: restrict GitHub Actions deployment to main branch only

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy Docusaurus to GitHub Pages
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
## Summary
- Remove pull_request trigger from deploy workflow to prevent unnecessary CI/CD builds on PRs
- Workflow now only runs on pushes to the main branch
- Deployment steps already had branch protection, but now the entire workflow is optimized

## Test plan
- [ ] Verify workflow only triggers on main branch pushes
- [ ] Confirm PRs no longer trigger the build workflow
- [ ] Ensure deployment still works correctly when merged to main

🤖 Generated with [Claude Code](https://claude.ai/code)