### PR TITLE
fix: resolve TypeScript error for redundant sale phase check

### DIFF
--- a/src/components/sections/Section4.tsx
+++ b/src/components/sections/Section4.tsx
@@ -1019,9 +1019,8 @@ const Section4: React.FC = () => {
                                 </div>
                             )}
 
-                            {/* Countdown Timer Section - Hide completely when sale ended */}
-                            {timerState.phase !== 'sale-ended' && (
-                                <div className="w-full flex flex-col items-center">
+                            {/* Countdown Timer Section */}
+                            <div className="w-full flex flex-col items-center">
                                     <Typography
                                         sx={{
                                             color: theme.palette.primary.main,
@@ -1044,8 +1043,7 @@ const Section4: React.FC = () => {
                                         <FlipClockCard value={timerState.timeRemaining.minutes} label="Minutes" theme={theme} />
                                         <FlipClockCard value={timerState.timeRemaining.seconds} label="Seconds" theme={theme} />
                                     </div>
-                                </div>
-                            )}
+                            </div>
                         </div>
                     </Card>
                 </div>


### PR DESCRIPTION
## Summary
- Fixed TypeScript error TS2367 that occurred after merging PR #38
- Removed redundant `timerState.phase \!== 'sale-ended'` check
- The check was inside a block that already excluded the 'sale-ended' phase

## Changes
- Removed redundant phase check on line 1023 in Section4.tsx
- Adjusted indentation after removing the unnecessary conditional wrapper

## Test Plan
- [x] Run `bun run typecheck` - passes without errors
- [x] Run `bun run build` - builds successfully
- [x] Verify countdown timer still displays correctly in pre-sale and public-mint phases
- [x] Verify sale ended display still shows when phase is 'sale-ended'

🤖 Generated with [Claude Code](https://claude.ai/code)