### PR TITLE
feat: add documentation link to homepage header

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -113,7 +113,26 @@ const Header: React.FC = () => {
                         className={`transition-all duration-150 ${scrolled ? 'h-14 sm:h-16' : 'h-16 sm:h-20'}`}
                     />
                 </Link>
-                <div>
+                <div className="flex items-center gap-4">
+                    <Link 
+                        href="/docs/intro"
+                        className="text-white hover:text-[#FCB040] transition-all duration-200 font-medium hover:transform hover:-translate-y-[1px]"
+                        style={{
+                            textDecoration: 'none',
+                            fontSize: '16px',
+                            padding: '8px 16px',
+                            borderRadius: '8px',
+                            display: 'inline-block'
+                        }}
+                        onMouseEnter={(e) => {
+                            e.currentTarget.style.backgroundColor = 'rgba(252, 176, 64, 0.1)';
+                        }}
+                        onMouseLeave={(e) => {
+                            e.currentTarget.style.backgroundColor = 'transparent';
+                        }}
+                    >
+                        Docs
+                    </Link>
                     {connectedWallet ? (
                         <div className="flex items-center gap-1">
                             <div
@@ -179,9 +198,11 @@ const Header: React.FC = () => {
                                     sx={{
                                         borderRadius: "16px"
                                     }}
-                                    PaperProps={{
-                                        sx: {
-                                            borderRadius: '16px',
+                                    slotProps={{
+                                        paper: {
+                                            sx: {
+                                                borderRadius: '16px',
+                                            },
                                         },
                                     }}
                                 >

--- a/src/components/sections/Section5.tsx
+++ b/src/components/sections/Section5.tsx
@@ -47,7 +47,7 @@ const Section5: React.FC = () => {
                             <Typography
                                 sx={{
                                     fontFamily: "Cinzel",
-                                    color: theme.palette.secondary.dark,
+                                    color: theme.palette.background.default,
                                     fontWeight: 900
                                 }}
                                 className="!text-center !text-[32px] sm:!text-[40px] lg:!text-[52px] xl:!text-[64px]"
@@ -56,7 +56,7 @@ const Section5: React.FC = () => {
                             </Typography>   
                             <Typography
                                 sx={{
-                                    color: theme.palette.text.secondary,
+                                    color: theme.palette.background.default,
                                     textAlign: "center",
                                     fontWeight: 500
                                 }}


### PR DESCRIPTION
## Summary
- Added "Docs" link to the homepage header for easy navigation to documentation
- Fixed text color contrast issue in the community section

## Changes

### Header Navigation
- Added "Docs" link next to the wallet connect button
- Styled with white text that changes to orange (#FCB040) on hover
- Added subtle background highlight and lift effect on hover
- Clean, minimalist design that matches the existing header style

### Section5 Fix
- Updated "JOIN THE COMMUNITY" section text colors
- Changed from brown/beige to dark charcoal (#151412) for better contrast
- Text is now clearly readable against the orange background

### Technical Updates
- Fixed deprecated `PaperProps` warning by using `slotProps.paper` instead

## Screenshots
The header now includes a "Docs" link that provides easy access to the documentation from the main landing page, improving user navigation and discoverability of the Angel Finance documentation.

🤖 Generated with [Claude Code](https://claude.ai/code)