### PR TITLE
fix: resolve duplicate slotProps attribute build error

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -194,16 +194,14 @@ const Header: React.FC = () => {
                                         list: {
                                             'aria-labelledby': 'basic-button',
                                         },
-                                    }}
-                                    sx={{
-                                        borderRadius: "16px"
-                                    }}
-                                    slotProps={{
                                         paper: {
                                             sx: {
                                                 borderRadius: '16px',
                                             },
                                         },
+                                    }}
+                                    sx={{
+                                        borderRadius: "16px"
                                     }}
                                 >
                                     <div className="w-72 !rounded-2xl">


### PR DESCRIPTION
## Summary
Fixes TypeScript build error that was preventing successful deployment.

## Error Fixed
```
src/components/common/Header.tsx(201,37): error TS17001: JSX elements cannot have multiple attributes with the same name.
```

## Changes
- Merged duplicate `slotProps` attributes on the Menu component into a single object
- Combined both `list` and `paper` configurations into one `slotProps` prop

## Verification
- ✅ `bun run typecheck` now passes without errors
- ✅ `bun run build` completes successfully

This is a critical fix to resolve the build failure in production.

🤖 Generated with [Claude Code](https://claude.ai/code)