### PR TITLE
fix: update Levvy section whitepaper link to internal docs

### DIFF
--- a/src/components/sections/Section3.tsx
+++ b/src/components/sections/Section3.tsx
@@ -126,8 +126,7 @@ const Section3: React.FC = () => {
                         </Typography>
                         <div className="flex items-center !gap-4">
                             <Button
-                                href="https://ccardano.gitbook.io/angel-paper/levvy-finance"
-                                target="_blank"
+                                href="/docs/angel-paper/levvy/what-is-levvy"
                                 startIcon={<img src="/images/icons/white_paper.svg" alt="White Paper Icon" />}
                                 sx={{
                                     backgroundColor: theme.palette.levvy.primary,


### PR DESCRIPTION
## Summary
- Updated the White Paper button in the Levvy section (Section3) to link to internal documentation
- Follows the same pattern as PR #43 for the homepage whitepaper button

## Changes
- Changed link from `https://ccardano.gitbook.io/angel-paper/levvy-finance` to `/docs/angel-paper/levvy/what-is-levvy`
- Removed `target="_blank"` attribute for internal navigation

🤖 Generated with [Claude Code](https://claude.ai/code)