### PR TITLE
fix: restore original theme colors for buttons and wallet icon

### DIFF
--- a/src/components/common/MainLayout.tsx
+++ b/src/components/common/MainLayout.tsx
@@ -88,7 +88,7 @@ const theme = createTheme({
           paper: "#232121"
         },
         primary: {
-          light: "#FFFF7F",
+          light: "#FFD89F",
           main: "#FCB040",
           dark: "#B77828",
           contrastText: "#151412"
@@ -96,7 +96,7 @@ const theme = createTheme({
         secondary: {
           light: "#F8F8F8",
           main: "#E1B33A",
-          dark: "#9E611E"
+          dark: "#432C00"
         },
         text: {
           primary: "#FFFFFF",
@@ -106,7 +106,7 @@ const theme = createTheme({
         levvy: {
           primary: "#FCB040",
           secondary: "#B77828",
-          secondary_dark: "#9E611E"
+          secondary_dark: "#432C00"
         },
         gradient: {
           levvy: {
@@ -115,7 +115,7 @@ const theme = createTheme({
             main_dark: "#E1B33A",
             secondary: "#B77828",
             secondary_light: "#232121",
-            secondary_dark: "#9E611E"
+            secondary_dark: "#432C00"
           },
           button: {
             10: "#EDDCBD",
@@ -123,7 +123,7 @@ const theme = createTheme({
             30: "#B77828",
             40: "#E1B33A",
             50: "#232121",
-            60: "#9E611E",
+            60: "#432C00",
             70: "#F8F8F8",
           },
           background: {


### PR DESCRIPTION
## Summary
- Restored the original color palette for the Token Sale/White Paper buttons and wallet icon
- Buttons now use the softer warm golden yellow (#FFD89F) instead of bright yellow (#FFFF7F)
- Wallet icon now uses the original dark brown (#432C00) instead of lighter brown (#9E611E)

## Changes
- `primary.light`: #FFFF7F → #FFD89F (button backgrounds)
- `secondary.dark`: #9E611E → #432C00 (wallet icon color)
- Updated all related color references to maintain consistency

## Visual Impact
- Token Sale and White Paper buttons have a warmer, softer golden background
- Connect Wallet button icon is now darker for better contrast
- Overall more cohesive with the original design aesthetic

🤖 Generated with [Claude Code](https://claude.ai/code)