### PR TITLE
Fix: Update footer links to use local docs paths

### DIFF
--- a/docs/angel-paper/introduction.md
+++ b/docs/angel-paper/introduction.md
@@ -6,10 +6,6 @@ description: Learn about Angel Finance's journey and mission on Cardano
 
 # 👋 Introduction
 
-<div style={{marginBottom: '2rem'}}>
-  <img src="/images/section1/angel.svg" alt="Angel Finance" style={{width: '100%', height: 'auto', maxHeight: '300px', objectFit: 'contain', padding: '2rem', borderRadius: '12px'}} />
-</div>
-
 ## Our Story
 
 Angel Finance is an Angel-themed DeFi project on Cardano. What started as a small DeFi investment club in January 2024 has evolved into something much greater.

--- a/src/components/common/Footer.tsx
+++ b/src/components/common/Footer.tsx
@@ -44,8 +44,7 @@ const Footer: React.FC = () => {
                 <div className="w-full flex items-center justify-between py-6 flex-col-reverse sm:flex-row">
                     <div className="flex items-ceter gap-4 md:gap-10 flex-col sm:flex-row">
                         <Link 
-                            href="https://ccardano.gitbook.io/angel-paper"
-                            target="_blank" rel="noopener noreferrer"
+                            href="/docs/whitepaper"
                             underline="hover"
                             sx={{
                                 color: theme.palette.text.primary,
@@ -58,8 +57,7 @@ const Footer: React.FC = () => {
                             </Typography>
                         </Link>
                         <Link 
-                            href="https://ccardano.gitbook.io/angel-paper/levvy-finance"
-                            target="_blank" rel="noopener noreferrer"
+                            href="/docs/documentation"
                             underline="hover"
                             sx={{
                                 color: theme.palette.text.primary,


### PR DESCRIPTION
## Summary
- Updated footer navigation links to point to local `/docs` paths instead of external GitBook URLs
- Removed the angel logo image from the introduction page that was displaying improperly
- Cleaned up link attributes (removed `target="_blank"` and `rel` attributes for internal links)

## Changes Made
1. **Footer Component Updates** (`src/components/common/Footer.tsx`):
   - Whitepaper link: `https://ccardano.gitbook.io/angel-paper` → `/docs/whitepaper`
   - Documentation link: `https://ccardano.gitbook.io/angel-paper/levvy-finance` → `/docs/documentation`

2. **Documentation Updates** (`docs/angel-paper/introduction.md`):
   - Removed the angel.svg image that was appearing half-cut/improperly displayed

## Test Plan
- [x] Verified footer links point to correct internal paths
- [x] Confirmed Terms of Service and Privacy Policy links remain unchanged
- [x] Checked that introduction page displays correctly without the image
- [ ] Test navigation to docs pages in development environment
- [ ] Verify docs structure supports `/docs/whitepaper` and `/docs/documentation` paths

🤖 Generated with [Claude Code](https://claude.ai/code)